### PR TITLE
Remove memory allocator fitness

### DIFF
--- a/gfx-memory/src/allocator/general.rs
+++ b/gfx-memory/src/allocator/general.rs
@@ -164,7 +164,7 @@ impl<B: Backend> GeneralAllocator<B> {
     pub fn new(
         memory_type: hal::MemoryTypeId,
         memory_properties: hal::memory::Properties,
-        config: GeneralConfig,
+        config: &GeneralConfig,
         non_coherent_atom_size: Size,
     ) -> Self {
         log::trace!(

--- a/gfx-memory/src/allocator/linear.rs
+++ b/gfx-memory/src/allocator/linear.rs
@@ -116,7 +116,7 @@ impl<B: Backend> LinearAllocator<B> {
     pub fn new(
         memory_type: hal::MemoryTypeId,
         memory_properties: hal::memory::Properties,
-        config: LinearConfig,
+        config: &LinearConfig,
         non_coherent_atom_size: Size,
     ) -> Self {
         log::trace!(

--- a/gfx-memory/src/lib.rs
+++ b/gfx-memory/src/lib.rs
@@ -20,7 +20,7 @@ mod usage;
 pub use crate::{
     allocator::*,
     block::Block,
-    heaps::{Heaps, HeapsConfig, HeapsError, MemoryBlock},
+    heaps::{Heaps, HeapsError, MemoryBlock},
     mapping::{MappedRange, Writer},
     memory::Memory,
     stats::*,

--- a/gfx-memory/src/usage.rs
+++ b/gfx-memory/src/usage.rs
@@ -1,7 +1,6 @@
 //! Defines usage types for memory bocks.
 //! See `Usage` and implementations for details.
 
-use crate::allocator::Kind;
 use hal::memory as m;
 
 /// Scenarios of how resources use memory.
@@ -60,21 +59,6 @@ impl MemoryUsage {
                 0 | ((properties.contains(m::Properties::CPU_CACHED) == read_back) as u32) << 1
                     | (!properties.contains(m::Properties::DEVICE_LOCAL) as u32) << 0
             }
-        }
-    }
-
-    pub(crate) fn allocator_fitness(&self, kind: Kind) -> u32 {
-        match *self {
-            MemoryUsage::Private | MemoryUsage::Dynamic { .. } => match kind {
-                Kind::Dedicated => 1,
-                Kind::General => 2,
-                Kind::Linear => 0,
-            },
-            MemoryUsage::Staging { .. } => match kind {
-                Kind::Dedicated => 0,
-                Kind::General => 1,
-                Kind::Linear => 2,
-            },
         }
     }
 }


### PR DESCRIPTION
Closes #1 

This PR makes it so every memory type has every allocator. An allocator is cheap if not used, there are no device operations or even heap allocations involved in creation.

Instead of trying to find an existing allocator based on the fitness function, we are passing the kind explicitly on every allocation. I believe the user is in a better position to control this explicitly when using the library, instead of assuming the library does the right thing.