### PR TITLE
Descriptor::raw_mut method

### DIFF
--- a/gfx-descriptor/src/allocator.rs
+++ b/gfx-descriptor/src/allocator.rs
@@ -29,6 +29,14 @@ impl<B: Backend> DescriptorSet<B> {
     pub fn raw(&self) -> &B::DescriptorSet {
         &self.raw
     }
+
+    /// Get a mutable reference to gfx-hal descriptor set.
+    ///
+    /// # Safety
+    /// Object needs not to be replaced.
+    pub unsafe fn raw_mut(&mut self) -> &mut B::DescriptorSet {
+        &mut self.raw
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Used by wgpu to set the name.