### PR TITLE
[mem] fix chunk refcounting in General allocator for dedicated blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## memory-0.1.3 (07-04-2020)
+  - fix chunk refcounting in General allocator for dedicated blocks
+
 ## memory-0.1.2 (05-04-2020)
   - fix freeing from General allocator
 

--- a/gfx-memory/Cargo.toml
+++ b/gfx-memory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-memory"
-version = "0.1.1"
+version = "0.1.3"
 authors = [
 	"omni-viral <scareaangel@gmail.com>",
 	"The Gfx-rs Developers",

--- a/gfx-memory/src/allocator/general.rs
+++ b/gfx-memory/src/allocator/general.rs
@@ -457,6 +457,7 @@ impl<B: Backend> GeneralAllocator<B> {
         if chunk.is_unused(block_size) {
             size_entry.ready_chunks.remove(chunk_index);
             let chunk = size_entry.chunks.remove(chunk_index as usize);
+            drop(block); // it keeps an Arc reference to the chunk
             self.free_chunk(device, chunk, block_size)
         } else {
             size_entry.ready_chunks.add(chunk_index);


### PR DESCRIPTION
Sibling of #10 
The cause of it was a removal of `dispose()` in blocks.