### PR TITLE
LinearAllocator cleanup

### DIFF
--- a/gfx-memory/src/allocator/dedicated.rs
+++ b/gfx-memory/src/allocator/dedicated.rs
@@ -99,7 +99,7 @@ pub struct DedicatedAllocator {
 }
 
 impl DedicatedAllocator {
-    /// Create new `LinearAllocator`
+    /// Create new `DedicatedAllocator`
     /// for `memory_type` with `memory_properties` specified
     pub fn new(
         memory_type: hal::MemoryTypeId,

--- a/gfx-memory/src/heaps/memory_type.rs
+++ b/gfx-memory/src/heaps/memory_type.rs
@@ -105,7 +105,7 @@ impl<B: hal::Backend> MemoryType<B> {
     }
 
     pub(super) fn clear(&mut self, device: &B::Device) {
-        log::trace!("Dispose memory allocators");
+        log::trace!("Clear memory allocators.");
         self.general.clear(device);
         self.linear.clear(device);
     }


### PR DESCRIPTION
I have a fix working for https://github.com/gfx-rs/wgpu-rs/issues/363
However the branch had gathered a LOT of cleanup changes, so I pulled them out into this separate branch, to make the actual changes easier to review afterwards.

The changes consist entirely of variable renames and new/changed comments.