### PR TITLE
Reuse finished lines in the linear allocator

### DIFF
--- a/gfx-memory/src/allocator/general.rs
+++ b/gfx-memory/src/allocator/general.rs
@@ -466,7 +466,9 @@ impl<B: Backend> GeneralAllocator<B> {
     }
 
     /// Free the contents of the allocator.
-    pub fn clear(&mut self, _device: &B::Device) {}
+    pub fn clear(&mut self, _device: &B::Device) -> Size {
+        0
+    }
 }
 
 impl<B: Backend> Allocator<B> for GeneralAllocator<B> {

--- a/gfx-memory/src/heaps/memory_type.rs
+++ b/gfx-memory/src/heaps/memory_type.rs
@@ -104,10 +104,9 @@ impl<B: hal::Backend> MemoryType<B> {
         }
     }
 
-    pub(super) fn clear(&mut self, device: &B::Device) {
+    pub(super) fn clear(&mut self, device: &B::Device) -> Size {
         log::trace!("Clear memory allocators.");
-        self.general.clear(device);
-        self.linear.clear(device);
+        self.general.clear(device) + self.linear.clear(device)
     }
 
     pub(super) fn utilization(&self) -> MemoryTypeUtilization {


### PR DESCRIPTION
This will fix https://github.com/gfx-rs/wgpu-rs/issues/363
But not https://github.com/gfx-rs/wgpu-rs/issues/261
Not sure why that is, maybe I need to do the same refactor to reuse buffers that I did for the project that was hitting 363. I'll investigate it later. Regardless it shouldn't block this fix for 363.

A concern I have:
Should the "Allocated line was freed but memory is still shared" error logs be replaced with panics to make them safe?"