### PR TITLE
Refactor block allocation to always respect the alignment

### DIFF
--- a/gfx-descriptor/src/allocator.rs
+++ b/gfx-descriptor/src/allocator.rs
@@ -46,19 +46,21 @@ struct Allocation<B: Backend> {
 }
 
 impl<B: Backend> Allocation<B> {
-    unsafe fn grow(
+    fn grow(
         &mut self,
         pool: &mut B::DescriptorPool,
         layout: &B::DescriptorSetLayout,
         count: u32,
     ) -> Result<(), OutOfMemory> {
         let sets_were = self.sets.len();
-        match pool.allocate(
-            std::iter::repeat(layout).take(count as usize),
-            &mut self.sets,
-        ) {
+        match unsafe {
+            pool.allocate(
+                std::iter::repeat(layout).take(count as usize),
+                &mut self.sets,
+            )
+        } {
             Err(err) => {
-                pool.free_sets(self.sets.drain(sets_were..));
+                unsafe { pool.free_sets(self.sets.drain(sets_were..)) };
                 Err(match err {
                     AllocationError::Host => OutOfMemory::Host,
                     AllocationError::Device => OutOfMemory::Device,
@@ -117,7 +119,7 @@ impl<B: Backend> DescriptorBucket<B> {
             .next_power_of_two() // rounded up to nearest 2^N
     }
 
-    unsafe fn dispose(mut self, device: &B::Device) {
+    fn dispose(mut self, device: &B::Device) {
         if self.total > 0 {
             log::error!("Not all descriptor sets were deallocated");
         }
@@ -129,11 +131,11 @@ impl<B: Backend> DescriptorBucket<B> {
                     pool
                 );
             }
-            device.destroy_descriptor_pool(pool.raw);
+            unsafe { device.destroy_descriptor_pool(pool.raw) };
         }
     }
 
-    unsafe fn allocate(
+    fn allocate(
         &mut self,
         device: &B::Device,
         layout: &B::DescriptorSetLayout,
@@ -173,11 +175,13 @@ impl<B: Backend> DescriptorBucket<B> {
                 size,
                 pool_counts,
             );
-            let mut raw = device.create_descriptor_pool(
-                size as usize,
-                pool_counts.iter(),
-                DescriptorPoolCreateFlags::FREE_DESCRIPTOR_SET,
-            )?;
+            let mut raw = unsafe {
+                device.create_descriptor_pool(
+                    size as usize,
+                    pool_counts.iter(),
+                    DescriptorPoolCreateFlags::FREE_DESCRIPTOR_SET,
+                )?
+            };
 
             let allocate = size.min(count);
             allocation.grow(&mut raw, layout, allocate)?;
@@ -199,30 +203,28 @@ impl<B: Backend> DescriptorBucket<B> {
         Ok(())
     }
 
-    unsafe fn free(
-        &mut self,
-        sets: impl IntoIterator<Item = B::DescriptorSet>,
-        pool_id: PoolIndex,
-    ) {
+    fn free(&mut self, sets: impl IntoIterator<Item = B::DescriptorSet>, pool_id: PoolIndex) {
         let pool = &mut self.pools[(pool_id - self.pools_offset) as usize];
         let mut count = 0;
-        pool.raw.free_sets(sets.into_iter().map(|set| {
-            count += 1;
-            set
-        }));
+        unsafe {
+            pool.raw.free_sets(sets.into_iter().map(|set| {
+                count += 1;
+                set
+            }))
+        };
         pool.available += count;
         self.total -= count as u64;
         log::trace!("Freed {} from descriptor bucket", count);
     }
 
-    unsafe fn cleanup(&mut self, device: &B::Device) {
+    fn cleanup(&mut self, device: &B::Device) {
         while let Some(pool) = self.pools.pop_front() {
             if pool.available < pool.capacity {
                 self.pools.push_front(pool);
                 break;
             }
             log::trace!("Destroying used up descriptor pool");
-            device.destroy_descriptor_pool(pool.raw);
+            unsafe { device.destroy_descriptor_pool(pool.raw) };
             self.pools_offset += 1;
         }
     }
@@ -248,7 +250,10 @@ impl<B: Backend> Drop for DescriptorAllocator<B> {
 
 impl<B: Backend> DescriptorAllocator<B> {
     /// Create new allocator instance.
-    pub fn new() -> Self {
+    ///
+    /// # Safety
+    /// All later operations assume the device is not lost.
+    pub unsafe fn new() -> Self {
         DescriptorAllocator {
             buckets: HashMap::default(),
             allocation: Allocation {
@@ -260,21 +265,13 @@ impl<B: Backend> DescriptorAllocator<B> {
         }
     }
 
-    /// Clear the allocator instance.
-    /// All sets allocated from this allocator become invalid.
-    pub unsafe fn clear(&mut self, device: &B::Device) {
-        for (_, bucket) in self.buckets.drain() {
-            bucket.dispose(device);
-        }
-    }
-
     /// Allocate descriptor set with specified layout.
     /// `DescriptorCounts` must match descriptor numbers of the layout.
     /// `DescriptorCounts` can be constructed [from bindings] that were used
     /// to create layout instance.
     ///
     /// [from bindings]: .
-    pub unsafe fn allocate(
+    pub fn allocate(
         &mut self,
         device: &B::Device,
         layout: &B::DescriptorSetLayout,
@@ -372,8 +369,19 @@ impl<B: Backend> DescriptorAllocator<B> {
         }
     }
 
+    /// Clear the allocator instance.
+    /// All sets allocated from this allocator become invalid.
+    ///
+    /// # Safety
+    /// Assumes none of the allocated blocks will be used from here.
+    pub unsafe fn clear(&mut self, device: &B::Device) {
+        for (_, bucket) in self.buckets.drain() {
+            bucket.dispose(device);
+        }
+    }
+
     /// Perform cleanup to allow resources reuse.
-    pub unsafe fn cleanup(&mut self, device: &B::Device) {
+    pub fn cleanup(&mut self, device: &B::Device) {
         for bucket in self.buckets.values_mut() {
             bucket.cleanup(device)
         }

--- a/gfx-descriptor/src/counts.rs
+++ b/gfx-descriptor/src/counts.rs
@@ -78,7 +78,7 @@ const DESCRIPTOR_TYPES: [DescriptorType; DESCRIPTOR_TYPES_COUNT] = [
     DescriptorType::InputAttachment,
 ];
 
-fn descriptor_type_index(ty: &DescriptorType) -> usize {
+fn descriptor_type_index(ty: DescriptorType) -> usize {
     match ty {
         DescriptorType::Sampler => 0,
         DescriptorType::Image {
@@ -155,7 +155,7 @@ fn descriptor_type_index(ty: &DescriptorType) -> usize {
 
 #[test]
 fn test_descriptor_types() {
-    for (index, ty) in DESCRIPTOR_TYPES.iter().enumerate() {
+    for (index, &ty) in DESCRIPTOR_TYPES.iter().enumerate() {
         assert_eq!(index, descriptor_type_index(ty));
     }
 }
@@ -175,7 +175,7 @@ impl DescriptorCounts {
     /// Add a single layout binding.
     /// Useful when created with `DescriptorCounts::EMPTY`.
     pub fn add_binding(&mut self, binding: DescriptorSetLayoutBinding) {
-        self.counts[descriptor_type_index(&binding.ty)] += binding.count as u32;
+        self.counts[descriptor_type_index(binding.ty)] += binding.count as u32;
     }
 
     /// Iterate through counts yelding descriptor types and their amount.
@@ -208,7 +208,7 @@ impl FromIterator<DescriptorSetLayoutBinding> for DescriptorCounts {
         let mut descs = Self::EMPTY;
 
         for binding in iter {
-            descs.counts[descriptor_type_index(&binding.ty)] += binding.count as u32;
+            descs.counts[descriptor_type_index(binding.ty)] += binding.count as u32;
         }
 
         descs

--- a/gfx-descriptor/src/lib.rs
+++ b/gfx-descriptor/src/lib.rs
@@ -9,7 +9,7 @@
     unused_import_braces,
     unused_qualifications
 )]
-
+#[allow(clippy::new_without_default)]
 mod allocator;
 mod counts;
 

--- a/gfx-memory/src/allocator/linear.rs
+++ b/gfx-memory/src/allocator/linear.rs
@@ -144,7 +144,7 @@ impl<B: Backend> LinearAllocator<B> {
     pub fn new(
         memory_type: hal::MemoryTypeId,
         memory_properties: hal::memory::Properties,
-        config: &LinearConfig,
+        config: LinearConfig,
         non_coherent_atom_size: Size,
     ) -> Self {
         log::trace!(
@@ -191,12 +191,10 @@ impl<B: Backend> LinearAllocator<B> {
                 unsafe {
                     freed += line.free_memory(device);
                 }
+            } else if Arc::strong_count(&line.memory) == 1 {
+                self.unused_lines.push(line);
             } else {
-                if Arc::strong_count(&line.memory) == 1 {
-                    self.unused_lines.push(line);
-                } else {
-                    log::error!("Allocated `Line` was freed, but memory is still shared.");
-                }
+                log::error!("Allocated `Line` was freed, but memory is still shared.");
             }
         }
         freed

--- a/gfx-memory/src/heaps/memory_type.rs
+++ b/gfx-memory/src/heaps/memory_type.rs
@@ -33,8 +33,8 @@ impl<B: hal::Backend> MemoryType<B> {
     pub(super) fn new(
         type_id: hal::MemoryTypeId,
         hal_memory_type: &hal::adapter::MemoryType,
-        general_config: &GeneralConfig,
-        linear_config: &LinearConfig,
+        general_config: GeneralConfig,
+        linear_config: LinearConfig,
         non_coherent_atom_size: Size,
     ) -> Self {
         MemoryType {

--- a/gfx-memory/src/heaps/mod.rs
+++ b/gfx-memory/src/heaps/mod.rs
@@ -66,6 +66,9 @@ pub struct Heaps<B: hal::Backend> {
 
 impl<B: hal::Backend> Heaps<B> {
     /// Initialize the new `Heaps` object.
+    ///
+    /// # Safety
+    /// All later operations assume the device is not lost.
     pub unsafe fn new(
         hal_memory_properties: &hal::adapter::MemoryProperties,
         config_general: GeneralConfig,
@@ -82,8 +85,8 @@ impl<B: hal::Backend> Heaps<B> {
                     MemoryType::new(
                         hal::MemoryTypeId(index),
                         mt,
-                        &config_general,
-                        &config_linear,
+                        config_general,
+                        config_linear,
                         non_coherent_atom_size,
                     )
                 })
@@ -169,8 +172,8 @@ impl<B: hal::Backend> Heaps<B> {
             align
         );
 
-        let ref mut memory_type = self.types[memory_index as usize];
-        let ref mut memory_heap = self.heaps[memory_type.heap_index()];
+        let memory_type = &mut self.types[memory_index as usize];
+        let memory_heap = &mut self.heaps[memory_type.heap_index()];
 
         if memory_heap.available() < size {
             return Err(hal::device::OutOfMemory::Device.into());
@@ -204,8 +207,8 @@ impl<B: hal::Backend> Heaps<B> {
             size,
         );
 
-        let ref mut memory_type = self.types[memory_index as usize];
-        let ref mut memory_heap = self.heaps[memory_type.heap_index()];
+        let memory_type = &mut self.types[memory_index as usize];
+        let memory_heap = &mut self.heaps[memory_type.heap_index()];
         let freed = memory_type.free(device, block.flavor);
         memory_heap.freed(freed, size);
     }
@@ -218,7 +221,7 @@ impl<B: hal::Backend> Heaps<B> {
     /// internal [`LinearAllocator`] and [`GeneralAllocator`] instances.
     pub fn clear(&mut self, device: &B::Device) {
         for memory_type in self.types.iter_mut() {
-            let ref mut memory_heap = self.heaps[memory_type.heap_index()];
+            let memory_heap = &mut self.heaps[memory_type.heap_index()];
             let freed = memory_type.clear(device);
             memory_heap.freed(freed, 0);
         }

--- a/gfx-memory/src/lib.rs
+++ b/gfx-memory/src/lib.rs
@@ -9,6 +9,7 @@
     unused_import_braces,
     unused_qualifications
 )]
+#[allow(clippy::new_without_default)]
 mod allocator;
 mod block;
 mod heaps;

--- a/gfx-memory/src/usage.rs
+++ b/gfx-memory/src/usage.rs
@@ -30,15 +30,16 @@ pub enum MemoryUsage {
 
 impl MemoryUsage {
     /// Set of required memory properties for this usage.
-    pub fn properties_required(&self) -> m::Properties {
-        match *self {
+    pub fn properties_required(self) -> m::Properties {
+        match self {
             MemoryUsage::Private => m::Properties::DEVICE_LOCAL,
             MemoryUsage::Dynamic { .. } | MemoryUsage::Staging { .. } => m::Properties::CPU_VISIBLE,
         }
     }
 
-    pub(crate) fn memory_fitness(&self, properties: m::Properties) -> u32 {
-        match *self {
+    #[allow(clippy::identity_op)]
+    pub(crate) fn memory_fitness(self, properties: m::Properties) -> u32 {
+        match self {
             MemoryUsage::Private => {
                 assert!(properties.contains(m::Properties::DEVICE_LOCAL));
                 0 | (!properties.contains(m::Properties::CPU_VISIBLE) as u32) << 3


### PR DESCRIPTION
Addresses https://github.com/gfx-rs/wgpu/issues/750
~~The actual fix is a single line in the second commit :)~~
First commit addresses the clippy warnings.
Second one has logic changes.

## Safety changes

I tried to bring gfx-descriptor in line with gfx-memory with regards to safety of the methods. Basically, methods receiving `&B::Device` assume that it's well and alive. We only put `unsafe` on where there are extra guarantees that can't be held by the type system.