### PR TITLE
Fully use NonZero in gfx-memory

### DIFF
--- a/gfx-memory/src/heaps/heap.rs
+++ b/gfx-memory/src/heaps/heap.rs
@@ -1,13 +1,13 @@
 use crate::{
     stats::{MemoryHeapUtilization, MemoryUtilization},
-    Size,
+    RawSize, Size,
 };
 
 #[derive(Debug)]
 pub(super) struct MemoryHeap {
     size: Size,
-    used: Size,
-    effective: Size,
+    used: RawSize,
+    effective: RawSize,
 }
 
 impl MemoryHeap {
@@ -19,22 +19,22 @@ impl MemoryHeap {
         }
     }
 
-    pub(super) fn available(&self) -> Size {
-        if self.used > self.size {
+    pub(super) fn available(&self) -> RawSize {
+        if self.used > self.size.get() {
             log::warn!("Heap size exceeded");
             0
         } else {
-            self.size - self.used
+            self.size.get() - self.used
         }
     }
 
-    pub(super) fn allocated(&mut self, used: Size, effective: Size) {
+    pub(super) fn allocated(&mut self, used: RawSize, effective: RawSize) {
         self.used += used;
         self.effective += effective;
         debug_assert!(self.used >= self.effective);
     }
 
-    pub(super) fn freed(&mut self, used: Size, effective: Size) {
+    pub(super) fn freed(&mut self, used: RawSize, effective: RawSize) {
         self.used -= used;
         self.effective -= effective;
         debug_assert!(self.used >= self.effective);

--- a/gfx-memory/src/mapping.rs
+++ b/gfx-memory/src/mapping.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{memory::Memory, Size},
+    crate::{memory::Memory, RawSize},
     hal::{device::Device as _, Backend},
     std::{iter, ops::Range, ptr::NonNull, slice},
 };
@@ -56,11 +56,11 @@ pub struct MappedRange<'a, B: Backend> {
     ptr: NonNull<u8>,
 
     /// Range of mapped memory.
-    mapping_range: Range<Size>,
+    mapping_range: Range<RawSize>,
 
     /// Mapping range requested by caller.
     /// Must be subrange of `mapping_range`.
-    requested_range: Range<Size>,
+    requested_range: Range<RawSize>,
 }
 
 impl<'a, B: Backend> MappedRange<'a, B> {
@@ -74,8 +74,8 @@ impl<'a, B: Backend> MappedRange<'a, B> {
     pub(crate) unsafe fn from_raw(
         memory: &'a Memory<B>,
         ptr: *mut u8,
-        mapping_range: Range<Size>,
-        requested_range: Range<Size>,
+        mapping_range: Range<RawSize>,
+        requested_range: Range<RawSize>,
     ) -> Self {
         debug_assert!(
             mapping_range.start < mapping_range.end,
@@ -120,7 +120,7 @@ impl<'a, B: Backend> MappedRange<'a, B> {
     }
 
     /// Get mapped range.
-    pub fn range(&self) -> Range<Size> {
+    pub fn range(&self) -> Range<RawSize> {
         self.requested_range.clone()
     }
 

--- a/gfx-memory/src/memory.rs
+++ b/gfx-memory/src/memory.rs
@@ -1,4 +1,4 @@
-use crate::{AtomSize, Size};
+use crate::Size;
 
 /// Memory object wrapper.
 /// Contains size and properties of the memory.
@@ -7,7 +7,7 @@ pub struct Memory<B: hal::Backend> {
     raw: B::Memory,
     size: Size,
     properties: hal::memory::Properties,
-    pub(crate) non_coherent_atom_size: Option<AtomSize>,
+    pub(crate) non_coherent_atom_size: Option<Size>,
 }
 
 impl<B: hal::Backend> Memory<B> {
@@ -40,7 +40,7 @@ impl<B: hal::Backend> Memory<B> {
         raw: B::Memory,
         size: Size,
         properties: hal::memory::Properties,
-        non_coherent_atom_size: Option<AtomSize>,
+        non_coherent_atom_size: Option<Size>,
     ) -> Self {
         debug_assert_eq!(
             non_coherent_atom_size.is_some(),

--- a/gfx-memory/src/stats.rs
+++ b/gfx-memory/src/stats.rs
@@ -1,4 +1,4 @@
-use crate::Size;
+use crate::{RawSize, Size};
 #[cfg(feature = "colorful")]
 use colorful::{core::color_string::CString, Color, Colorful as _};
 use hal::memory::Properties;
@@ -7,9 +7,9 @@ use hal::memory::Properties;
 #[derive(Clone, Copy, Debug)]
 pub struct MemoryUtilization {
     /// Total number of bytes allocated.
-    pub used: Size,
+    pub used: RawSize,
     /// Effective number bytes allocated.
-    pub effective: Size,
+    pub effective: RawSize,
 }
 
 /// Memory utilization of one heap.
@@ -48,11 +48,11 @@ pub struct TotalMemoryUtilization {
 #[cfg(feature = "colorful")]
 impl std::fmt::Display for TotalMemoryUtilization {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        const MB: Size = 1024 * 1024;
+        const MB: RawSize = 1024 * 1024;
 
         writeln!(fmt, "!!! Memory utilization !!!")?;
         for (index, heap) in self.heaps.iter().enumerate() {
-            let size = heap.size;
+            let size = heap.size.get();
             let MemoryUtilization { used, effective } = heap.utilization;
             let usage_basis_points = used * 10000 / size;
             let fill = if usage_basis_points > 10000 {
@@ -106,7 +106,7 @@ impl std::fmt::Display for TotalMemoryUtilization {
 }
 
 #[cfg(feature = "colorful")]
-fn format_basis_points(basis_points: Size) -> CString {
+fn format_basis_points(basis_points: RawSize) -> CString {
     debug_assert!(basis_points <= 10000);
     let s = format!("{:>3}.{:02}%", basis_points / 100, basis_points % 100);
     if basis_points > 7500 {
@@ -123,7 +123,7 @@ fn format_basis_points(basis_points: Size) -> CString {
 }
 
 #[cfg(feature = "colorful")]
-fn format_basis_points_inverted(basis_points: Size) -> CString {
+fn format_basis_points_inverted(basis_points: RawSize) -> CString {
     debug_assert!(basis_points <= 10000);
     let s = format!("{:>3}.{:02}%", basis_points / 100, basis_points % 100);
     if basis_points > 9900 {


### PR DESCRIPTION
It could be nice to expose the NonZero contract for the API side when passing down allocation sizes and alignments.
Previously, the conditions on parameters where:
  1. size is not zero
  2. alignment is not zero
  3. size is aligned

Now, it's just (3), size is aligned.