### PR TITLE
Prevent empty descriptors from being created

### DIFF
--- a/gfx-descriptor/src/allocator.rs
+++ b/gfx-descriptor/src/allocator.rs
@@ -283,6 +283,11 @@ impl<B: Backend> DescriptorAllocator<B> {
             return Ok(());
         }
 
+        assert!(
+            !layout_counts.is_empty(),
+            "Allocating an empty descriptor layout is not valid",
+        );
+
         log::trace!(
             "Allocating {} sets with layout {:?} @ {:?}",
             count,

--- a/gfx-descriptor/src/counts.rs
+++ b/gfx-descriptor/src/counts.rs
@@ -175,6 +175,11 @@ impl DescriptorCounts {
         counts: [0; DESCRIPTOR_TYPES_COUNT],
     };
 
+    /// Returns true if this indicates a completely empty descriptor layout.
+    pub fn is_empty(&self) -> bool {
+        self.counts == Self::EMPTY.counts
+    }
+
     /// Add a single layout binding.
     /// Useful when created with `DescriptorCounts::EMPTY`.
     pub fn add_binding(&mut self, binding: DescriptorSetLayoutBinding) {


### PR DESCRIPTION
Disallows the allocation of empty descriptor layouts. Fixes https://github.com/gfx-rs/wgpu/issues/240.