### PR TITLE
[memory-0.2.1] prevent over-allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## memory-0.2.1 (12-10-2020)
+  - remove `hibitset` dependency
+  - fix overallocating memory when nothing is allocated yet
+  - fix overallocating memory after a few cycles of allocation
+
 ## memory-0.2, descriptor-0.2
   - update to gfx-hal-0.6
   - remove `colorful` dependency

--- a/gfx-memory/Cargo.toml
+++ b/gfx-memory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-memory"
-version = "0.2.0"
+version = "0.2.1"
 authors = [
 	"omni-viral <scareaangel@gmail.com>",
 	"The Gfx-rs Developers",

--- a/gfx-memory/Cargo.toml
+++ b/gfx-memory/Cargo.toml
@@ -18,7 +18,6 @@ description = "gfx-hal memory allocator"
 [dependencies]
 fxhash = "0.2"
 hal = { package = "gfx-hal", version = "0.6" }
-hibitset = { version = "0.6", default-features = false }
 log = "0.4"
 slab = "0.4"
 

--- a/gfx-memory/src/allocator/general.rs
+++ b/gfx-memory/src/allocator/general.rs
@@ -193,7 +193,9 @@ mod bit {
                 if self.index >= Self::TOTAL {
                     return None;
                 }
-                if self.index & (BitSet::GROUP_SIZE - 1) == 0 && (self.groups & (1 << (self.index / BitSet::GROUP_SIZE))) == 0 {
+                if self.index & (BitSet::GROUP_SIZE - 1) == 0
+                    && (self.groups & (1 << (self.index / BitSet::GROUP_SIZE))) == 0
+                {
                     self.index += BitSet::GROUP_SIZE;
                 } else {
                     if (self.mask & (1 << self.index)) != 0 {
@@ -383,6 +385,13 @@ impl<B: Backend> GeneralAllocator<B> {
             Some(&chunk_size) => {
                 // Allocate block for the chunk.
                 self.alloc_from_entry(device, chunk_size, 1, block_size)?
+            }
+            None if requested_chunk_size > self.min_device_allocation => {
+                // Allocate memory block from the device.
+                // Note: if we call into `alloc_block` instead, we are going to be
+                // going larger and larger blocks until we hit the ceiling.
+                let chunk = self.alloc_chunk_from_device(device, block_size, clamped_count)?;
+                return Ok((chunk, requested_chunk_size));
             }
             None => {
                 // Allocate a new block for the chunk.

--- a/gfx-memory/src/allocator/mod.rs
+++ b/gfx-memory/src/allocator/mod.rs
@@ -58,6 +58,7 @@ unsafe fn allocate_memory_helper<B: hal::Backend>(
 ) -> Result<(Memory<B>, Option<NonNull<u8>>), hal::device::AllocationError> {
     use hal::device::Device as _;
 
+    log::trace!("Raw allocation of size {} for type {:?}", size, memory_type);
     let raw = device.allocate_memory(memory_type, size)?;
 
     let ptr = if memory_properties.contains(hal::memory::Properties::CPU_VISIBLE) {


### PR DESCRIPTION
This is an extract from #31 that makes sense to release as a published version, with improvements.
Specifically, #32 and #33 are addressed here.